### PR TITLE
feat[#2]: add target time setting and fix remaining time display

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,11 +9,21 @@ function startTimer() {
   startTime = Date.now() - pausedTime;
 
   intervalId = setInterval(() => {
-    const elapsed = Math.floor((Date.now() - startTime) / 1000);
-    const minutes = Math.floor(elapsed / 60);
-    const text = `${minutes}m`;
-    chrome.action.setBadgeText({ text });
-    chrome.action.setBadgeBackgroundColor({ color: "#4688F1" });
+    chrome.storage.local.get(['targetMinutes'], (result) => {
+        const target = result.targetMinutes || 30;
+        const elapsed = Math.floor((Date.now() - startTime) / 1000);
+        const remaining = target * 60 - elapsed;
+      
+        if (remaining >= 0) {
+          const min = Math.floor(remaining / 60);
+          chrome.action.setBadgeText({ text: `${min}m` });
+          chrome.action.setBadgeBackgroundColor({ color: "#4688F1" }); // normal
+        } else {
+          const overtime = Math.abs(Math.floor(remaining / 60));
+          chrome.action.setBadgeText({ text: `+${overtime}m` });
+          chrome.action.setBadgeBackgroundColor({ color: "#E74C3C" }); // overtime
+        }
+      });      
   }, 1000);
 }
 

--- a/popup.html
+++ b/popup.html
@@ -2,14 +2,34 @@
 <html>
 <head>
   <style>
-    body { font-family: sans-serif; min-width: 200px; padding: 10px; }
-    button { margin: 5px 0; width: 100%; }
+    body {
+      font-family: sans-serif;
+      min-width: 200px;
+      padding: 10px;
+    }
+    label {
+      display: block;
+      margin-top: 10px;
+      font-weight: bold;
+    }
+    input {
+      width: 100%;
+      margin-bottom: 10px;
+    }
+    button {
+      margin: 5px 0;
+      width: 100%;
+    }
   </style>
 </head>
 <body>
+  <label for="targetTime">Target Time (minutes)</label>
+  <input type="number" id="targetTime" min="1" value="30" />
+
   <button id="start">Start</button>
   <button id="pause">Pause</button>
   <button id="reset">Reset</button>
+
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,11 +1,24 @@
+const input = document.getElementById('targetTime');
+
+// 로드 시 저장된 타겟 시간 불러오기
+chrome.storage.local.get(['targetMinutes'], (result) => {
+  input.value = result.targetMinutes || 30;
+});
+
+// 값이 바뀌면 저장
+input.addEventListener('input', (e) => {
+  const value = parseInt(e.target.value, 10);
+  if (!isNaN(value) && value > 0) {
+    chrome.storage.local.set({ targetMinutes: value });
+  }
+});
+
 document.getElementById('start').addEventListener('click', () => {
-    chrome.runtime.sendMessage({ action: 'startTimer' });
+  chrome.runtime.sendMessage({ action: 'startTimer' });
 });
-
 document.getElementById('pause').addEventListener('click', () => {
-    chrome.runtime.sendMessage({ action: 'pauseTimer' });
+  chrome.runtime.sendMessage({ action: 'pauseTimer' });
 });
-
 document.getElementById('reset').addEventListener('click', () => {
-    chrome.runtime.sendMessage({ action: 'resetTimer' });
+  chrome.runtime.sendMessage({ action: 'resetTimer' });
 });


### PR DESCRIPTION
## 📌 Summary

Allow users to set a custom target time and display remaining time (instead of elapsed) on the badge.

---

## ✅ Changes

- [x] Add input field in popup.html to set target time
- [x] Save and load targetMinutes using chrome.storage.local
- [x] Display remaining time on badge instead of elapsed time
- [x] Show overtime with `+Xm` format and change badge color to red

---

## 🔗 Related Issue

Closes #2

---

## 💬 Additional Notes

Target time defaults to 30 minutes. Delay logic and reset behavior will be refined in a future issue.
