### PR TITLE
Feat[#3]: calculate and display delay time including seconds

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,25 +10,38 @@ function startTimer() {
 
   intervalId = setInterval(() => {
     chrome.storage.local.get(['targetMinutes'], (result) => {
-        const targetMinutes = result.targetMinutes || 30;
-        const targetSeconds = targetMinutes * 60;
-      
-        const elapsedSeconds = Math.floor((Date.now() - startTime) / 1000);
-        const delaySeconds = Math.max(elapsedSeconds - targetSeconds, 0);
-        
-        const badgeText = delaySeconds > 0
-          ? `+${Math.floor(delaySeconds / 60)}m`
-          : `${Math.ceil((targetSeconds - elapsedSeconds) / 60)}m`;
-      
-        const badgeColor = delaySeconds > 0 ? '#E74C3C' : '#4688F1';
-      
-        chrome.action.setBadgeText({ text: badgeText });
-        chrome.action.setBadgeBackgroundColor({ color: badgeColor });
-      
-        // 타이머 지연 시간 저장
-        currentDelay = delaySeconds;
-      });      
-  }, 1000);
+      const targetMinutes = result.targetMinutes || 30;
+      const targetSeconds = targetMinutes * 60;
+      const elapsed = Math.floor((Date.now() - startTime) / 1000);
+      const remaining = targetSeconds - elapsed;
+  
+      let badgeText = '';
+      let badgeColor = '#4688F1';
+  
+      if (remaining >= 0) {
+        if (remaining >= 60) {
+          badgeText = `${Math.ceil(remaining / 60)}m`;
+        } else {
+          badgeText = `${remaining}s`;
+        }
+      } else {
+        const overtime = Math.abs(remaining);
+        badgeColor = '#E74C3C';
+  
+        if (overtime >= 60) {
+          badgeText = `+${Math.floor(overtime / 60)}m`;
+        } else {
+          badgeText = `+${overtime}s`;
+        }
+      }
+  
+      chrome.action.setBadgeText({ text: badgeText });
+      chrome.action.setBadgeBackgroundColor({ color: badgeColor });
+  
+      // delay 상태 저장
+      chrome.storage.local.set({ delaySeconds: Math.max(-remaining, 0) });
+    });
+  }, 1000);  
 }
 
 function pauseTimer() {

--- a/background.js
+++ b/background.js
@@ -10,19 +10,23 @@ function startTimer() {
 
   intervalId = setInterval(() => {
     chrome.storage.local.get(['targetMinutes'], (result) => {
-        const target = result.targetMinutes || 30;
-        const elapsed = Math.floor((Date.now() - startTime) / 1000);
-        const remaining = target * 60 - elapsed;
+        const targetMinutes = result.targetMinutes || 30;
+        const targetSeconds = targetMinutes * 60;
       
-        if (remaining >= 0) {
-          const min = Math.floor(remaining / 60);
-          chrome.action.setBadgeText({ text: `${min}m` });
-          chrome.action.setBadgeBackgroundColor({ color: "#4688F1" }); // normal
-        } else {
-          const overtime = Math.abs(Math.floor(remaining / 60));
-          chrome.action.setBadgeText({ text: `+${overtime}m` });
-          chrome.action.setBadgeBackgroundColor({ color: "#E74C3C" }); // overtime
-        }
+        const elapsedSeconds = Math.floor((Date.now() - startTime) / 1000);
+        const delaySeconds = Math.max(elapsedSeconds - targetSeconds, 0);
+        
+        const badgeText = delaySeconds > 0
+          ? `+${Math.floor(delaySeconds / 60)}m`
+          : `${Math.ceil((targetSeconds - elapsedSeconds) / 60)}m`;
+      
+        const badgeColor = delaySeconds > 0 ? '#E74C3C' : '#4688F1';
+      
+        chrome.action.setBadgeText({ text: badgeText });
+        chrome.action.setBadgeBackgroundColor({ color: badgeColor });
+      
+        // 타이머 지연 시간 저장
+        currentDelay = delaySeconds;
       });      
   }, 1000);
 }


### PR DESCRIPTION
## 📌 Summary

Calculate delay time when elapsed time exceeds target time, and update badge to show remaining or overtime in both minutes and seconds.

---

## ✅ Changes

- [x] Calculate delay time using elapsedSeconds - targetSeconds
- [x] Update badge to display seconds when under 1 minute
- [x] Format badge text as `45s`, `+20s`, `2m`, `+3m`
- [x] Change badge color to red when overtime
- [x] Store `delaySeconds` to chrome.storage.local for future use

---

## 🔗 Related Issue

Closes #3

---

## 💬 Additional Notes

Display logic now shows more accurate time in short intervals.  
Future improvements may include visual or sound alerts based on delay.